### PR TITLE
Allow the .eot extension

### DIFF
--- a/packages/cms-lib/lib/constants.js
+++ b/packages/cms-lib/lib/constants.js
@@ -17,6 +17,7 @@ const ALLOWED_EXTENSIONS = new Set([
   'map',
   'svg',
   'ttf',
+  'eot',
   'woff',
   'woff2',
 ]);


### PR DESCRIPTION
I got a weird problem in my HS project: `.eot` font files didn't get uploaded to my theme, throwing this error:
```
[ERROR] The file "sr-theme-customized/fonts/suisse-intl/SuisseIntl-Black-WebS.eot" does not have a valid extension
```

This PR adds it to the ALLOWED_EXTENSIONS list.

Is there a good reason why it was not included?
